### PR TITLE
Remove alphacephei.com maven repo

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -3,9 +3,6 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven {
-            url 'https://alphacephei.com/maven/'
-        }
         maven { url "https://jitpack.io" }
     }
 }
@@ -15,9 +12,6 @@ dependencyResolutionManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven {
-            url 'https://alphacephei.com/maven/'
-        }
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
It seems Alphacephei has also published their libraries on Maven Central. Their own documentation recommends Maven Central instead of their repo: https://alphacephei.com/vosk/install

The APK therefore builds as before.

This aids in making Sayboard compatible with F-Droid's inclusion criteria, which lists Maven Central and the other already used maven repos as trusted and allowed: https://f-droid.org/en/docs/Inclusion_Policy/